### PR TITLE
[bherly] Fix output plugin for kubernetes using annotations

### DIFF
--- a/fluent-plugin-barito.gemspec
+++ b/fluent-plugin-barito.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-barito"
-  spec.version = "0.1.10"
+  spec.version = "0.1.11"
   spec.authors = ["BaritoLog"]
   spec.email   = ["pushm0v.development@gmail.com", "iman.tung@gmail.com"]
 
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'coveralls', '~> 0.8.21'
   spec.add_development_dependency 'test-unit', '~> 3.2'
-  
+
   spec.add_runtime_dependency "fluentd", "~> 0.12", ">= 0.12.0"
   spec.add_runtime_dependency "rest-client", "~> 2"
 end

--- a/lib/fluent/plugin/out_barito_k8s.rb
+++ b/lib/fluent/plugin/out_barito_k8s.rb
@@ -7,17 +7,10 @@ module Fluent
   class BaritoK8sOutput < BufferedOutput
 
     PLUGIN_NAME = 'barito_k8s'
-    
-    LABEL_APP_SECRET = 'baritoApplicationSecret'
-    LABEL_PRODUCE_HOST = 'baritoProduceHost'
-    LABEL_PRODUCE_PORT = 'baritoProducePort'
-    LABEL_PRODUCE_TOPIC = 'baritoProduceTopic'
-    
+    LABEL_APP_SECRET = 'barito.applicationSecret'
+    LABEL_PRODUCE_URL = 'barito.produceUrl'
 
     Fluent::Plugin.register_output(PLUGIN_NAME, self)
-    
-    config_param :use_https, :bool, :default => false
-    
 
     # Overide from BufferedOutput
     def start
@@ -31,38 +24,28 @@ module Fluent
 
     # Overide from BufferedOutput
     def write(chunk)
-      
       chunk.msgpack_each do |tag, time, record|
-        labels = record['kubernetes']['labels']
-        url = produce_url(labels)
-        secret = application_secret(labels)
-        
-        trail = Fluent::Plugin::ClientTrail.new(true)
-        
+        params = record['kubernetes']['annotations']
+
+        next if params.nil?
+        url = produce_url(params)
+        secret = application_secret(params)
+
+        next if url.nil? or secret.nil?
+        trail = Fluent::Plugin::ClientTrail.new(false)
         timber = Fluent::Plugin::TimberFactory::create_timber(tag, time, record, trail)
         header = {content_type: :json, 'X-App-Secret' => secret}
-        
+
         RestClient.post url, timber.to_json, header
       end
     end
-    
-    def produce_url(labels)
-      produce_host = labels[LABEL_PRODUCE_HOST]
-      produce_port = labels[LABEL_PRODUCE_PORT]
-      produce_topic = labels[LABEL_PRODUCE_TOPIC]
-      
-      protocol = @use_https? 'https' : 'http'
-      
-      produce_url = "#{protocol}://#{produce_host}:#{produce_port}/produce/#{produce_topic}"
-      produce_url
-    end
-    
-    def application_secret(labels)
-      labels[LABEL_APP_SECRET]
-    end
-    
-    
-  end
-  
 
+    def produce_url(params)
+      params[LABEL_PRODUCE_URL]
+    end
+
+    def application_secret(params)
+      params[LABEL_APP_SECRET]
+    end
+  end
 end


### PR DESCRIPTION
Since k8s `labels` is not intended storing large amount of information, we are switching to `annotations`. The values to be captured are `barito.applicationSecret` & `barito.produceUrl`. Incoming log records will be filtered by `kubernetes metadata filter` plugin before processing by this plugin.