### PR TITLE
Refactor kubernetes output

### DIFF
--- a/fluent-plugin-barito.gemspec
+++ b/fluent-plugin-barito.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-barito"
-  spec.version = "0.1.11"
+  spec.version = "0.1.12"
   spec.authors = ["BaritoLog"]
   spec.email   = ["pushm0v.development@gmail.com", "iman.tung@gmail.com"]
 


### PR DESCRIPTION
To tidy up log message, remove `kubernetes` & `docker` field from log record, append it into `timber` object.